### PR TITLE
Add dnsmasq_config_override option

### DIFF
--- a/hassio-access-point/CHANGELOG.md
+++ b/hassio-access-point/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Notes:
 - Error: "wlan0: Could not connect to kernel driver" - https://raspberrypi.stackexchange.com/a/88297
+- Added a new config addon option: dnsmasq_config_override to allow additions/overrides to the dnsmasq config file, for example in order to add static DHCP leases with the dhcp-host= option. This option operates similarly to hostapd_config_override.
 
 ## [0.4.1] - 2021-07-21
 

--- a/hassio-access-point/config.json
+++ b/hassio-access-point/config.json
@@ -30,7 +30,8 @@
     "debug": 0,
     "hostapd_config_override": [],
     "client_internet_access": "0",
-    "client_dns_override": []
+    "client_dns_override": [],
+    "dnsmasq_config_override": []
   },
   "schema": {
     "ssid": "str",
@@ -49,6 +50,7 @@
     "debug": "int",
     "hostapd_config_override": ["str"],
     "client_internet_access": "int",
-    "client_dns_override": ["str"]
+    "client_dns_override": ["str"],
+    "dnsmasq_config_override": ["str"]
   }
 } 

--- a/hassio-access-point/run.sh
+++ b/hassio-access-point/run.sh
@@ -31,12 +31,14 @@ HIDE_SSID=$(jq --raw-output ".hide_ssid" $CONFIG_PATH)
 DHCP=$(jq --raw-output ".dhcp" $CONFIG_PATH)
 DHCP_START_ADDR=$(jq --raw-output ".dhcp_start_addr" $CONFIG_PATH)
 DHCP_END_ADDR=$(jq --raw-output ".dhcp_end_addr" $CONFIG_PATH)
+DNSMASQ_CONFIG_OVERRIDE=$(jq --raw-output '.dnsmasq_config_override | join(" ")' $CONFIG_PATH)
 ALLOW_MAC_ADDRESSES=$(jq --raw-output '.allow_mac_addresses | join(" ")' $CONFIG_PATH)
 DENY_MAC_ADDRESSES=$(jq --raw-output '.deny_mac_addresses | join(" ")' $CONFIG_PATH)
 DEBUG=$(jq --raw-output '.debug' $CONFIG_PATH)
 HOSTAPD_CONFIG_OVERRIDE=$(jq --raw-output '.hostapd_config_override | join(" ")' $CONFIG_PATH)
 CLIENT_INTERNET_ACCESS=$(jq --raw-output ".client_internet_access" $CONFIG_PATH)
 CLIENT_DNS_OVERRIDE=$(jq --raw-output '.client_dns_override | join(" ")' $CONFIG_PATH)
+DNSMASQ_CONFIG_OVERRIDE=$(jq --raw-output '.dnsmasq_config_override | join(" ")' $CONFIG_PATH)
 
 # Set interface as wlan0 if not specified in config
 if [ ${#INTERFACE} -eq 0 ]; then
@@ -197,10 +199,20 @@ if [ $DHCP -eq 1 ]; then
             fi
 
         fi
+
+    # Append override options to dnsmasq.conf
+    if [ ${#DNSMASQ_CONFIG_OVERRIDE} -ge 1 ]; then
+        logger "# Custom dnsmasq config options:" 0
+        DNSMASQ_OVERRIDES=($DNSMASQ_CONFIG_OVERRIDE)
+        for override in "${DNSMASQ_OVERRIDES[@]}"; do
+            echo "$override"$'\n' >> /dnsmasq.conf
+            logger "Add to dnsmasq.conf: $override" 0
+        done
+    fi
     
     # Setup Client Internet Access
     if [ $CLIENT_INTERNET_ACCESS -eq 1 ]; then
-        
+
         ## Route traffic
         iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
         iptables -P FORWARD ACCEPT


### PR DESCRIPTION
Use case: I have some wireless IP cameras which I cannot set static IPs on directly. This makes them unusable with hostapd without modification.

With the changes in this PR one is able to set a static IP for the devices and thus code them into the dashboard or use them with other software correctly.

I have simply copy pasted the code here from hostapd for a quick fix, hope that suffices.