### PR TITLE
Fix startup error on S6-Overlay 3.x

### DIFF
--- a/hassio-access-point/config.json
+++ b/hassio-access-point/config.json
@@ -13,6 +13,7 @@
   "privileged": [
     "NET_ADMIN"
   ],
+  "init": false,
   "options": {
     "ssid": "",
     "wpa_passphrase": "",


### PR DESCRIPTION
The upgrade of the home assistant base images to use s6-Overlay v3 has broken the addon. It now gives the following error on startup:
```
s6-overlay-suexec: fatal: can only run as pid 1
```
I have made the changes proposed on https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/ to fix the addon(init: false and execution bit to run.sh). Now it's working again.