### PR TITLE
Add iptables to container

### DIFF
--- a/hassio-access-point/CHANGELOG.md
+++ b/hassio-access-point/CHANGELOG.md
@@ -6,7 +6,12 @@
 - Error: "wlan0: Could not connect to kernel driver" - https://raspberrypi.stackexchange.com/a/88297
 - **If anyone has any knowledge relating to the underlying modules, or just wants to assist with testing this addon, please get in touch, submit PRs, etc.**
 
-## [0.4.6] - 2022-04-23
+## [0.4.7] - 2023-06-23
+
+### Fixed
+- IPtables dependency change as noted in [issue 42](https://github.com/mattlongman/Hassio-Access-Point/issues/42#issuecomment-1579294919). Thanks to [@tomduijf](https://github.com/tomduijf) for submitting [PR 48](https://github.com/mattlongman/Hassio-Access-Point/pull/48).
+
+## [0.4.6] - 2023-04-23
 
 ### Bump to revert 0.4.5
 

--- a/hassio-access-point/Dockerfile
+++ b/hassio-access-point/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV LANG C.UTF-8
 
 RUN apk update && \
-apk add --no-cache bash jq iw hostapd networkmanager networkmanager-cli net-tools sudo dnsmasq && \
+apk add --no-cache bash jq iw hostapd networkmanager networkmanager-cli net-tools sudo dnsmasq iptables && \
 rm -rf /var/cache/apk/*
 
 COPY hostapd.conf /

--- a/hassio-access-point/config.json
+++ b/hassio-access-point/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Hass.io Access Point",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "slug": "hassio-access-point",
   "description": "Create a WiFi access point to directly connect devices to Home Assistant",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],


### PR DESCRIPTION
Hi,

As pointed out [here](https://github.com/mattlongman/Hassio-Access-Point/issues/42#issuecomment-1579294919), it seems the `iptables` package is missing in the container, when enabling `client_internet_access`

Small PR;
- also install `iptables` when building the container.
- bump version to `0.4.7`

Tested on rpi/hassos, fixes problem, no regressions found
