### PR TITLE
Forward internet to default route instead of hard coded eth0

### DIFF
--- a/hassio-access-point/CHANGELOG.md
+++ b/hassio-access-point/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Error: "wlan0: Could not connect to kernel driver" - https://raspberrypi.stackexchange.com/a/88297
 - **If anyone has any knowledge relating to the underlying modules, or just wants to assist with testing this addon, please get in touch, submit PRs, etc.**
 
+## [0.4.8] - 2023-10-19
+
+### Fixed
+- [PR-56](https://github.com/mattlongman/Hassio-Access-Point/pull/56) from [rrooggiieerr](https://github.com/rrooggiieerr): "Breaking Change: On Arm based boards network names are enumerated based on device tree. This means that the first Ethernet devices will no longer be named eth0 but end0. This pull request proposes a solution by using the default route interface to forward client internet access to."
+
 ## [0.4.7] - 2023-06-23
 
 ### Fixed

--- a/hassio-access-point/config.json
+++ b/hassio-access-point/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Hass.io Access Point",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "slug": "hassio-access-point",
   "description": "Create a WiFi access point to directly connect devices to Home Assistant",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],

--- a/hassio-access-point/run.sh
+++ b/hassio-access-point/run.sh
@@ -41,7 +41,7 @@ CLIENT_DNS_OVERRIDE=$(jq --raw-output '.client_dns_override | join(" ")' $CONFIG
 DNSMASQ_CONFIG_OVERRIDE=$(jq --raw-output '.dnsmasq_config_override | join(" ")' $CONFIG_PATH)
 
 # Get the Default Route interface
-DEFAULT_ROUTE_INTERFACE=$(ip route show default | awk '{ print $5 }')
+DEFAULT_ROUTE_INTERFACE=$(ip route show default | awk '/^default/ { print $5 }')
 
 # Set interface as wlan0 if not specified in config
 if [ ${#INTERFACE} -eq 0 ]; then


### PR DESCRIPTION
Home Assistant OS 11.0 breaks client_internet_access

From the Home Assistant OS 11.0 change log:

⚠️ Breaking Change: On Arm based boards network names are enumerated based on device tree. This means that the first Ethernet devices will no longer be named eth0 but end0.

This pull request proposes a solution by using the default route interface to forward client internet access to.

I tested my modifications and client internet access is working again on Home Assistant OS 11.0