### PR TITLE
Add support for changing HT capabilities

### DIFF
--- a/hassio-access-point/config.yaml
+++ b/hassio-access-point/config.yaml
@@ -28,6 +28,7 @@ options:
   allow_mac_addresses: []
   deny_mac_addresses: []
   debug: 0
+  ht_capab: "[HT40][SHORT-GI-20][DSSS_CCK-40]"
   hostapd_config_override: []
   client_internet_access: false
   client_dns_override: []
@@ -49,6 +50,7 @@ schema:
   deny_mac_addresses:
     - match(^([0-9a-fA-F]{2}:){4}[0-9a-fA-F]{2})?
   debug: int(0,2)
+  ht_capab: match(^(\[[A-Z0-9][A-Z0-9_+-]*\])+$)
   hostapd_config_override:
     - str?
   client_internet_access: bool

--- a/hassio-access-point/hostapd.conf
+++ b/hassio-access-point/hostapd.conf
@@ -10,9 +10,6 @@ ieee80211n=1
 # Enable WMM
 wmm_enabled=1
 
-# Enable 40MHz channels with 20ns guard interval
-ht_capab=[HT40][SHORT-GI-20][DSSS_CCK-40]
-
 # Bit field: 1=wpa, 2=wep, 3=both
 auth_algs=1
 

--- a/hassio-access-point/run.sh
+++ b/hassio-access-point/run.sh
@@ -47,6 +47,7 @@ DNSMASQ_CONFIG_OVERRIDE=$(bashio::config 'dnsmasq_config_override' )
 ALLOW_MAC_ADDRESSES=$(bashio::config 'allow_mac_addresses' )
 DENY_MAC_ADDRESSES=$(bashio::config 'deny_mac_addresses' )
 DEBUG=$(bashio::config 'debug' )
+HT_CAPAB=$(bashio::config "ht_capab" )
 HOSTAPD_CONFIG_OVERRIDE=$(bashio::config 'hostapd_config_override' )
 CLIENT_INTERNET_ACCESS=$(bashio::config.false 'client_internet_access'; echo $?)
 CLIENT_DNS_OVERRIDE=$(bashio::config 'client_dns_override' )
@@ -83,7 +84,7 @@ ip link set $INTERFACE up
 trap 'term_handler' SIGTERM
 
 # Enforces required env variables
-required_vars=(ssid wpa_passphrase channel address netmask broadcast)
+required_vars=(ssid wpa_passphrase channel address netmask broadcast ht_capab)
 for required_var in "${required_vars[@]}"; do
     bashio::config.require $required_var "An AP cannot be created without this information"
 done
@@ -102,6 +103,8 @@ logger "Add to hostapd.conf: channel=$CHANNEL" 1
 echo "channel=$CHANNEL"'\n' >> /hostapd.conf
 logger "Add to hostapd.conf: ignore_broadcast_ssid=$HIDE_SSID" 1
 echo "ignore_broadcast_ssid=$HIDE_SSID"$'\n' >> /hostapd.conf
+logger "Add to hostapd.conf: ht_capab=$HT_CAPAB" 1
+echo "ht_capab=$HT_CAPAB"$'\n' >> /hostapd.conf
 
 ### MAC address filtering
 ## Allow is more restrictive, so we prioritise that and set

--- a/hassio-access-point/translations/en.json
+++ b/hassio-access-point/translations/en.json
@@ -56,6 +56,10 @@
 			"name": "",
 			"description": ""
 		},
+		"ht_capab": {
+			"name": "HT Capabilities",
+			"description": "HT capabilities (list of flags)"
+		},
 		"hostapd_config_override": {
 			"name": "HOSTAPD Custom Configuration",
 			"description": "A list of options to append to the `hostapd.conf` file. Don't touch if you don't know what you're doing."

--- a/hassio-access-point/translations/fr.json
+++ b/hassio-access-point/translations/fr.json
@@ -56,6 +56,10 @@
 			"name": "",
 			"description": ""
 		},
+		"ht_capab": {
+			"name": "HT Capabilities",
+			"description": "Capacités HT (liste des drapeaux)"
+		},
 		"hostapd_config_override": {
 			"name": "Configuration personnalisée de HOSTAPD",
 			"description": "Liste d'options à ajouter au fichier `hostpad.conf`. Ne pas modifier si vous ne savez pas ce que vous faîtes."


### PR DESCRIPTION
This change introduces a way to change HT capabilities. This is necessary if you'd like to use an external USB WiFi adapter for example.