### PR TITLE
fix for ht-capab default value

### DIFF
--- a/hassio-access-point/config.yaml
+++ b/hassio-access-point/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Hass.io Access Point
-version: 0.5.3.2
+version: 0.5.3.3
 slug: hassio-access-point
 description: Create a WiFi access point to directly connect devices to Home Assistant
 arch: [armhf, armv7, aarch64, amd64, i386]

--- a/hassio-access-point/run.sh
+++ b/hassio-access-point/run.sh
@@ -47,10 +47,7 @@ DNSMASQ_CONFIG_OVERRIDE=$(bashio::config 'dnsmasq_config_override' )
 ALLOW_MAC_ADDRESSES=$(bashio::config 'allow_mac_addresses' )
 DENY_MAC_ADDRESSES=$(bashio::config 'deny_mac_addresses' )
 DEBUG=$(bashio::config 'debug' )
-HT_CAPAB=$(bashio::config 'ht_capab')
-if [ -z "${HT_CAPAB}" ] || [ "${HT_CAPAB}" = "null" ]; then
-  HT_CAPAB='[HT40][SHORT-GI-20][DSSS_CCK-40]'
-fi
+HT_CAPAB=$(bashio::config 'ht_capab' '[HT40][SHORT-GI-20][DSSS_CCK-40]')
 HOSTAPD_CONFIG_OVERRIDE=$(bashio::config 'hostapd_config_override' )
 CLIENT_INTERNET_ACCESS=$(bashio::config.false 'client_internet_access'; echo $?)
 CLIENT_DNS_OVERRIDE=$(bashio::config 'client_dns_override' )


### PR DESCRIPTION
bashio::config takes 2 args: option name and default value. This change updates the call to get `ht_capab` value to provide default value.
See: https://github.com/hassio-addons/bashio/blob/main/lib/config.sh