### PR TITLE
Remove ht_capab from options

### DIFF
--- a/hassio-access-point/config.yaml
+++ b/hassio-access-point/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Hass.io Access Point
-version: 0.5.3.3
+version: 0.5.3.4
 slug: hassio-access-point
 description: Create a WiFi access point to directly connect devices to Home Assistant
 arch: [armhf, armv7, aarch64, amd64, i386]


### PR DESCRIPTION
Remove ht_capab from options
Presence in `options` gives a default value (null) which overrides the optional flag in `schema`. It's now hidden in the options list until you check the 'Show unused optional configuration options' toggle at the bottom.