### PR TITLE
Add support for custom commands

### DIFF
--- a/hassio-access-point/config.yaml
+++ b/hassio-access-point/config.yaml
@@ -32,6 +32,7 @@ options:
   client_internet_access: false
   client_dns_override: []
   dnsmasq_config_override: []
+  custom_commands: []
 schema:
   ssid: match(^.{2,32}$)
   wpa_passphrase: password
@@ -56,4 +57,6 @@ schema:
   client_dns_override:
     - match(^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)
   dnsmasq_config_override:
+    - str?
+  custom_commands:
     - str?

--- a/hassio-access-point/config.yaml
+++ b/hassio-access-point/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Hass.io Access Point
-version: 0.5.4
+version: 0.5.4-1
 slug: hassio-access-point
 description: Create a WiFi access point to directly connect devices to Home Assistant
 arch: [armhf, armv7, aarch64, amd64, i386]

--- a/hassio-access-point/run.sh
+++ b/hassio-access-point/run.sh
@@ -243,6 +243,12 @@ if $(bashio::config.true "dhcp"); then
     dnsmasq -C /dnsmasq.conf
 fi
 
+while IFS= read -r cmd; do
+  [ -z "$cmd" ] && continue
+  echo "Running: $cmd"
+  eval "$cmd"
+done <<< "$(bashio::config 'custom_commands')"
+
 logger "## Starting hostapd daemon" 1
 # If debug level is greater than 1, start hostapd in debug mode
 if [ $DEBUG -gt 1 ]; then

--- a/hassio-access-point/translations/en.json
+++ b/hassio-access-point/translations/en.json
@@ -75,6 +75,10 @@
 		"dnsmasq_config_override": {
 			"name": "DNSMASQ Custom Configuration",
 			"description": "A list of options to append to the `dnsmasq.conf` file. Don't touch if you don't know what you're doing."
+		},
+		"custom_commands": {
+			"name": "Custom Commands",
+			"description": "A list of commands that will be executed before `hostapd` is started. Don't touch if you don't know what you're doing."
 		}
 	}
 }


### PR DESCRIPTION
Added list of commands that are executed before `hostapd` is started.
I needed to execute some extra commands, like adding firewall rules.

This currently uses eval, which may have security implications if the commands are not trusted. 