### PR TITLE
Set BUILD_FROM

### DIFF
--- a/hassio-access-point/Dockerfile
+++ b/hassio-access-point/Dockerfile
@@ -1,7 +1,7 @@
-ARG BUILD_FROM
+ARG BUILD_FROM="alpine"
 FROM $BUILD_FROM
 
-MAINTAINER ex-ml <ex_ml@sent.com>
+LABEL maintainer="ex-ml <ex_ml@sent.com>
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
To address #116 - I'm not able to test this, but setting a base rather than previous behaviour should fix, ref https://community.home-assistant.io/t/resolved-noob-dockerfile-question-on-arg-build-from/795519/5