### PR TITLE
Add build file

### DIFF
--- a/hassio-access-point/Dockerfile
+++ b/hassio-access-point/Dockerfile
@@ -1,18 +1,26 @@
-ARG BUILD_FROM="alpine"
+ARG BUILD_FROM
 FROM $BUILD_FROM
-
-ENV LANG C.UTF-8
-
-RUN apk update && \
-    apk add --no-cache bash iw hostapd networkmanager networkmanager-cli net-tools sudo dnsmasq iptables && \
-    rm -rf /var/cache/apk/*
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY hostapd.conf / 
-COPY dnsmasq.conf / 
+ENV LANG=C.UTF-8
 
-COPY run.sh / 
+RUN apk update && \
+    apk add --no-cache \
+        iw \
+        hostapd \
+        networkmanager \
+        networkmanager-cli \
+        net-tools \
+        sudo \
+        dnsmasq \
+        iptables && \
+    rm -rf /var/cache/apk/*
+
+COPY hostapd.conf /
+COPY dnsmasq.conf /
+
+COPY run.sh /
 RUN chmod a+x /run.sh
 
 CMD [ "/run.sh" ]

--- a/hassio-access-point/build.yaml
+++ b/hassio-access-point/build.yaml
@@ -1,0 +1,6 @@
+build_from:
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.21
+  amd64: ghcr.io/home-assistant/amd64-base:3.21
+  armhf: ghcr.io/home-assistant/armhf-base:3.21
+  armv7: ghcr.io/home-assistant/armv7-base:3.21
+  i386: ghcr.io/home-assistant/i386-base:3.21

--- a/hassio-access-point/config.yaml
+++ b/hassio-access-point/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Hass.io Access Point
-version: 0.5.4.4
+version: 0.5.4.5
 slug: hassio-access-point
 description: Create a WiFi access point to directly connect devices to Home Assistant
 arch: [armhf, armv7, aarch64, amd64, i386]


### PR DESCRIPTION
Add build.yaml to specify different images, revert dockerfile back to `ARG BUILD_FROM`.

Set build image versions to 3.21. Looks like 3.23 is available, but that will need a change to what the addon supports.

#116 & #119 